### PR TITLE
Fix spelling mistakes "writting" -> "writing".

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ MindTheGap is composed of two main modules : breakpoint detection (`find` module
     Additional options are related to computational runtime and memory:
     * `-nb-cores`: number of cores to be used for computation [default '0', ie. all available cores will be used].
     * `-max-memory`: max RAM memory for the graph creation (in MBytes)  [default '2000']. Increasing the memory will speed up the graph creation phase.
-    * `-max-disk`: max usable disk space for the graph creation (in MBytes)  [default '0', ie. automatically set]. Kmers are counted by writting temporary files on the disk, to speed up the counting you can increase the usable disk space.
+    * `-max-disk`: max usable disk space for the graph creation (in MBytes)  [default '0', ie. automatically set]. Kmers are counted by writing temporary files on the disk, to speed up the counting you can increase the usable disk space.
 
 
 

--- a/src/Filler.cpp
+++ b/src/Filler.cpp
@@ -227,14 +227,14 @@ void Filler::execute ()
     _insert_file_name = getInput()->getStr(STR_URI_OUTPUT)+".insertions.fasta";
     _insert_file = fopen(_insert_file_name.c_str(), "w");
     if(_insert_file == NULL){
-        string message = "Cannot open file "+ _insert_file_name + " for writting";
+        string message = "Cannot open file "+ _insert_file_name + " for writing";
         throw Exception(message.c_str());
     }
 
     _insert_info_file_name = getInput()->getStr(STR_URI_OUTPUT)+".info.txt";
     _insert_info_file = fopen(_insert_info_file_name.c_str(), "w");
     if(_insert_info_file == NULL){
-        string message = "Cannot open file "+ _insert_info_file_name + " for writting";
+        string message = "Cannot open file "+ _insert_info_file_name + " for writing";
         throw Exception(message.c_str());
     }
 
@@ -245,8 +245,8 @@ void Filler::execute ()
         _vcf_file_name = getInput()->getStr(STR_URI_OUTPUT)+".insertions.vcf";
         _vcf_file = fopen(_vcf_file_name.c_str(), "w");
         if(_vcf_file == NULL){
-            //cerr <<" Cannot open file "<< _output_file <<" for writting" << endl;
-            string message = "Cannot open file "+ _vcf_file_name + " for writting";
+            //cerr <<" Cannot open file "<< _output_file <<" for writing" << endl;
+            string message = "Cannot open file "+ _vcf_file_name + " for writing";
             throw Exception(message.c_str());
         }
         writeVcfHeader();
@@ -259,7 +259,7 @@ void Filler::execute ()
         _gfa_file_name = getInput()->getStr(STR_URI_OUTPUT)+".gfa";
         _gfa_file = fopen(_gfa_file_name.c_str(),"w");
         if(_gfa_file == NULL){
-            string message = "Cannot open file "+ _gfa_file_name + " for writting";
+            string message = "Cannot open file "+ _gfa_file_name + " for writing";
             throw Exception(message.c_str());
         }
     }
@@ -1004,7 +1004,7 @@ void Filler::writeFilledBreakpoint(std::vector<filled_insertion_t>& filledSequen
         osolu_i <<   "solution " <<    it->solution_rank << "/" << it->solution_count ;
         string solu_i = it->solution_count >1 ?  osolu_i.str() : "" ;
         
-        //Writting sequence header
+        //Writing sequence header
         if(_breakpointMode) //-bkpt mode, to keep the same header name as before
         {
             fprintf(_insert_file,">%s_len_%d_qual_%i_avg_cov_%.2f_median_cov_%.2f   %s\n",
@@ -1022,7 +1022,7 @@ void Filler::writeFilledBreakpoint(std::vector<filled_insertion_t>& filledSequen
             fprintf(_insert_file,"%s",insertionName.c_str());
         }
         
-        //Writting DNA sequence
+        //Writing DNA sequence
         fprintf(_insert_file,"%.*s\n",(int)llen,insertion.c_str() );
         
 //        if(it->solution_count >1)

--- a/src/Finder.cpp
+++ b/src/Finder.cpp
@@ -281,16 +281,16 @@ void Finder::execute ()
     _breakpoint_file_name = getInput()->getStr(STR_URI_OUTPUT)+".breakpoints";
     _breakpoint_file = fopen(_breakpoint_file_name.c_str(), "w");
     if(_breakpoint_file == NULL){
-        //cerr <<" Cannot open file "<< _output_file <<" for writting" << endl;
-        string message = "Cannot open file "+ _breakpoint_file_name + " for writting";
+        //cerr <<" Cannot open file "<< _output_file <<" for writing" << endl;
+        string message = "Cannot open file "+ _breakpoint_file_name + " for writing";
         throw Exception(message.c_str());
     }
 
     _vcf_file_name = getInput()->getStr(STR_URI_OUTPUT)+".othervariants.vcf";
     _vcf_file = fopen(_vcf_file_name.c_str(), "w");
     if(_vcf_file == NULL){
-    	//cerr <<" Cannot open file "<< _output_file <<" for writting" << endl;
-    	string message = "Cannot open file "+ _vcf_file_name + " for writting";
+    	//cerr <<" Cannot open file "<< _output_file <<" for writing" << endl;
+    	string message = "Cannot open file "+ _vcf_file_name + " for writing";
     	throw Exception(message.c_str());
     }
     writeVcfHeader();


### PR DESCRIPTION
Currently maintaining MindTheGap as a [debian package]

Although informational based, lintian output refers to the generated deb package as having spelling mistakes: 

I: mindthegap: spelling-error-in-binary usr/bin/MindTheGap writting writing

I have used grep to locate the spelling mistakes and I have rectified them. A trivial PR but one less complaint / output by the lintian package checker. 

[debian package]: https://salsa.debian.org/med-team/mindthegap