### PR TITLE
Fix expression that cannot be used as a function

### DIFF
--- a/src/FindBreakpoints.hpp
+++ b/src/FindBreakpoints.hpp
@@ -783,7 +783,7 @@ typename FindBreakpoints<span>::KmerCanonical& FindBreakpoints<span>::kmer_end()
 template<size_t span>
 uint64_t FindBreakpoints<span>::solid_stretch_size()
 {
-    return this->m_solid_stretch_size();
+    return this->m_solid_stretch_size;
 }
 
 template<size_t span>


### PR DESCRIPTION
As reported in [Debian bug #1075273], starting with g++ 14, the build fails with the following error (that was missing from the semi automated report):

	/<<PKGBUILDDIR>>/src/FindBreakpoints.hpp:786:38: error: expression cannot be used as a function
	  786 |     return this->m_solid_stretch_size();
	      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~

Looking at other instances of the m_solid_stretch_size attribute, the use of the expression as a function seems to be erroneous and the intent seems to have been to return the plain integer number instead.

[Debian bug #1075273]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075273